### PR TITLE
Router endpoint framework

### DIFF
--- a/app/controllers/microservices_engine/v1/data_controller.rb
+++ b/app/controllers/microservices_engine/v1/data_controller.rb
@@ -6,6 +6,21 @@ module MicroservicesEngine
       def update
         # TO-DO
         # . . .
+
+        token = params.require(:token)
+        # TO-DO
+        #
+        # Add logic to verify token, perhaps send a request to the router
+        # to ask if the token is valid?
+
+        data = params.require(:content)
+        # TO-DO
+        #
+        # Generate connection objects / update existing connection objects
+        # based on the contents of the request.
+        #
+        # Requires knowledge of how the router will send data to engines
+        # so this will be delayed
       end
     end
   end


### PR DESCRIPTION
Adds the basic code for the endpoint that will take data from the router.

Requires most of the router to be complete and deployed, so this part will likely be done last.
