### PR TITLE
should we not allow rails greater than 3.0?

### DIFF
--- a/microservices-engine.gemspec
+++ b/microservices-engine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 3.0'
+  s.add_dependency 'rails', '>= 3.0'
 
   s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'webmock', '~> 2.1'

--- a/microservices-engine.gemspec
+++ b/microservices-engine.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '>= 3.0'
+  s.add_dependency 'rails', '>= 3.0', '<6.0'
 
   s.add_development_dependency 'rspec-rails', '~> 3.5'
   s.add_development_dependency 'webmock', '~> 2.1'


### PR DESCRIPTION
`~>` means allow greater minor version changes but not major. For example, `~> 2.1.0` would allow anything from  2.1.0 to 3.0 but no further. So, we've restricted ourselves to exactly rails 3 here.