### PR TITLE
start simplecov before loading path to dummy app

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
+require 'spec_helper'
 require File.expand_path('../../test/dummy/config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'spec_helper'
 require 'rspec/rails'
 require 'webmock/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!


### PR DESCRIPTION
If you pull from master right now and run rspec, your coverage % will be like 35. That's because we start SimpleCov _after_ loading the path to the dummy app, which for some reason makes any file in the lib directory show up as uncovered. I had to do a lot of Googling to figure this one out.